### PR TITLE
fix: add a new npm script to populate dist with support files

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node ./dist/app.js",
     "dev": "nodemon --exec node --loader ts-node/esm src/app.ts",
+    "nontstodist": "cp -r .knex dist/ && cp knexfile.js dist/ && cp src/knex.js dist/",
     "build": "cd ../client && npm install && npm run build && cd ../server && npm install && tsc",
     "migrate": "knex migrate:latest"
   },


### PR DESCRIPTION
# ✅ Resolves #[Issue number]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

since there is some knex support files required for operation, those must be copied manually below dist/

a new npm run script in the server/package.json has been setup for that purpose. it must be called inside at the end of the build
the call is ```npm run nontstodist```

### 🧪 Testing instructions

switch render on this branch
use for build: 
```cd ./client && npm install && npm run build && cd ../server && npm install && tsc && npm run nontstodist```

use for start:
```cd server && npm run migrate && cd && node ./server/dist/app.js```

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
