### PR TITLE
chore: enable japanconcertticket in config

### DIFF
--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -56,6 +56,14 @@ let _source: Array<EventSourceConfigType> = [
         controller: new JapancheapoEventSource(),
         searchType: ES_SEARCH_IN_CACHE,
         homeCountry: 'japan'
+    },
+    {
+        id: "japanconcerttickets",
+        enabled: true,
+        endpoint: "https://www.japanconcerttickets.com/wp-admin/admin-ajax.php",
+        controller: new JapanconcertticketsEventSource(),
+        searchType: ES_SEARCH_IN_CACHE,
+        homeCountry: "japan"
     }
 ]
 


### PR DESCRIPTION
# ✅ Resolves #41 (leftover)

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

the same data source was added in a previous PR, but the config file was not included.
even if we plan to not index at the end (by disabling it), the config will be complete and in-sync with the controller list

### 🧪 Testing instructions

see #41 for the detail. basicaly, seeding the data source by calling
```/api/internal/scrap/japanconcerttickets```
and then making a search to validate there is content in the local cache.

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
