### PR TITLE
fix: only reload firebaseAdmin if not already loaded, add missing controller for timeline event removal

### DIFF
--- a/server/src/controllers/timelineController.ts
+++ b/server/src/controllers/timelineController.ts
@@ -36,6 +36,32 @@ export const createTimelineEntry = async (
 };
 
 /**
+ * Controller: delete a new timeline entry
+ */
+export const deleteTimelineEntry = async (
+  req: Request<{}, {}, TimelineRequestBody>,
+  res: Response,
+): Promise<void> => {
+  try {
+    const { user_uid, event_id } = req.body;
+    if (!user_uid || !event_id) {
+      res.status(400).json({ error: 'Missing user_uid or event_id' });
+      return;
+    }
+
+    log.info(`Removing timeline entry for user: ${user_uid}, event: ${event_id}`);
+    const entry = await TimelineModel.deleteTimelineEntry(user_uid, event_id);
+
+    res.status(201).json({
+      message: 'Timeline entry removed',
+      data: entry
+    });
+  } catch (error) {
+    log.error('Error inserting timeline entry', error);
+  }
+};
+
+/**
  * Controller: retrieve all events joined by the authenticated user
  */
 export const getEventsForUser = async (

--- a/server/src/middlewares/authSync.ts
+++ b/server/src/middlewares/authSync.ts
@@ -7,10 +7,11 @@ import type { ServiceAccount } from 'firebase-admin';
 import serviceAccountRaw from '../../../serviceAccountKey.json' with { type: 'json' };
 
 // Initialize Firebase Admin SDK
-admin.initializeApp({
-  credential: admin.credential.cert(serviceAccountRaw as ServiceAccount),
-});
-
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccountRaw as ServiceAccount),
+  });
+}
 const auth = admin.auth();
 
 /**

--- a/server/src/utils/persistence.ts
+++ b/server/src/utils/persistence.ts
@@ -182,6 +182,8 @@ async function getLatestBackupContent(backupType: string): Promise<Array<Event>>
             .orderBy('created_at','desc')
             .first();
 
+        if (compressed === undefined) return [];
+        
         const decompressed = await zlib.ungzip(compressed.content);
         let data = JSON.parse(decompressed.toString());
 


### PR DESCRIPTION
fix: add missing controller for event removal from timeline

# ✅ Resolves #[Issue number]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

- fixes two regression introduced in https://github.com/Event-Curator/event-curator/pull/86

- since new routes are protected by authMiddleware, we need to check if firebase admin layer is not already loaded
  prevented the app to start.
- added missing controller in timelineController.js for event removal from timeline. prevended the app to start.

### 🧪 Testing instructions

lookup example call for event removal in the README.md

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
