### PR TITLE
Feat: media hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ serviceAccountKey.json
 backups/
 .env
 .vscode
+medias/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ serviceAccountKey.json
 backups/
 .env
 .vscode
-medias/
+media/

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,7 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 app.use(express.static("./client/dist"));
+app.use("/medias", express.static(`${config.mediaStoragePath}`));
 app.use("/api", eventRoute);
 app.use("/api", userRoute);
 app.use(errorHandler);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,7 +16,7 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 app.use(express.static("./client/dist"));
-app.use("/medias", express.static(`${config.mediaStoragePath}`));
+app.use("/media", express.static(`${config.mediaStoragePath}`));
 app.use("/api", eventRoute);
 app.use("/api", userRoute);
 app.use(errorHandler);

--- a/server/src/controllers/AllsportdbEventSource.ts
+++ b/server/src/controllers/AllsportdbEventSource.ts
@@ -13,6 +13,7 @@ import { EventCategoryEnum, EventType, Event } from '../models/Event.js';
 import config from '../utils/config.js';
 import { log } from '../utils/logger.js';
 import { DefaultEventSource } from './DefaultEventSource.js';
+import * as ec from "./eventController.js";
 
 class AllsportdbEventSource extends DefaultEventSource {
 
@@ -52,7 +53,10 @@ class AllsportdbEventSource extends DefaultEventSource {
             anEvent.name = event.competition;
             anEvent.description = event.name;
             anEvent.teaserText = event.sport;
+
             anEvent.teaserMedia = event.webUrl;
+            let localUrl = await ec.saveMedia(anEvent.teaserMedia);
+            if (localUrl) { anEvent.teaserMedia = localUrl };
 
             anEvent.budgetCurrency = this.CURRENCY;
             anEvent.budgetMin = 0;

--- a/server/src/controllers/JapancheapoEventSource.ts
+++ b/server/src/controllers/JapancheapoEventSource.ts
@@ -28,7 +28,7 @@ class JapancheapoEventSource extends DefaultEventSource {
       log.info(`${this.id}: scrapping started`);
 
       // FIXME: get back to 18
-      for (let i = 1; i<18; i++) {
+      for (let i = 1; i<2; i++) {
         log.info(`${this.id}: scrapping ongoing. page ${i}`);
 
         const res = await fetch(`https://japancheapo.com/events/page/${i}/`);

--- a/server/src/controllers/JapancheapoEventSource.ts
+++ b/server/src/controllers/JapancheapoEventSource.ts
@@ -28,7 +28,7 @@ class JapancheapoEventSource extends DefaultEventSource {
       log.info(`${this.id}: scrapping started`);
 
       // FIXME: get back to 18
-      for (let i = 1; i<2; i++) {
+      for (let i = 1; i<18; i++) {
         log.info(`${this.id}: scrapping ongoing. page ${i}`);
 
         const res = await fetch(`https://japancheapo.com/events/page/${i}/`);

--- a/server/src/controllers/JapancheapoEventSource.ts
+++ b/server/src/controllers/JapancheapoEventSource.ts
@@ -3,6 +3,8 @@ import { EventType, Event, EventCategoryEnum } from "../models/Event.js";
 import * as cheerio from "cheerio";
 import moment, { Moment } from 'moment';
 import { log } from "../utils/logger.js";
+import * as ec from "./eventController.js";
+
 moment().format();
 
 class JapancheapoEventSource extends DefaultEventSource {
@@ -34,8 +36,7 @@ class JapancheapoEventSource extends DefaultEventSource {
 
         const $ = cheerio.load(html);
         
-        $(".article.card--event").each((index, element) => {
-
+        for (let element of $(".article.card--event")) {
           let val = $(element).find('.card__cta').find('a').attr('href') || "";
           let anEvent = new Event(val);
 
@@ -47,6 +48,8 @@ class JapancheapoEventSource extends DefaultEventSource {
           val = $(element).find(".cheapo-archive-thumb").attr("src") || "";
 
           anEvent.teaserMedia = val.trim();
+          let localUrl = await ec.saveMedia(anEvent.teaserMedia);
+          if (localUrl) { anEvent.teaserMedia = localUrl };
 
           val = $(element).find(".card__content").find(".card__title").text() || "";
           anEvent.name = val.trim();
@@ -207,7 +210,7 @@ class JapancheapoEventSource extends DefaultEventSource {
           anEvent.placeFreeform = val.trim();
 
           events.push(anEvent);
-        });
+        };
 
       }
       log.info(`${this.id}: scrapping done. ${events.length} found.`);

--- a/server/src/controllers/JapanconcertticketsEventSource.ts
+++ b/server/src/controllers/JapanconcertticketsEventSource.ts
@@ -4,6 +4,8 @@ import * as cheerio from "cheerio";
 import moment, { Moment } from 'moment';
 import { log } from "../utils/logger.js";
 import config from "../utils/config.js";
+import * as ec from "./eventController.js";
+
 moment().format();
 
 class JapanconcertticketsEventSource extends DefaultEventSource {
@@ -162,7 +164,11 @@ class JapanconcertticketsEventSource extends DefaultEventSource {
           anEvent.teaserFreeform = val;
           
           let eventDetail = await this.getEventDetail(anEvent.originUrl, _eventDate);
+
           anEvent.teaserMedia = eventDetail.teaserMedia;
+          let localUrl = await ec.saveMedia(anEvent.teaserMedia);
+          if (localUrl) { anEvent.teaserMedia = localUrl };
+
           anEvent.description = eventDetail.description;
           anEvent.placeFreeform = eventDetail.placeFreeform;
           anEvent.budgetFreeform = eventDetail.budgetFreeform;

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -323,7 +323,7 @@ const getSearchHits = async function (req: Request, resp: Response) {
 // -------------------------- utility functions for website implementations
 
 // save the media behind a given url locally and return the "local url" (or undefined if error)
-// the return path can be used as the new filepath below express static "/medias"
+// the return path can be used as the new filepath below express static "/media"
 const saveMedia = async function (url: string) {
     const mediaResp = await fetch(url);
     if (mediaResp.status != 200) {
@@ -347,7 +347,7 @@ const saveMedia = async function (url: string) {
         }
     })
 
-    return `/medias/${fileName}`;
+    return `/media/${fileName}`;
 }
 
 export { scrapEvent, searchEvent, getEventById, getSearchHits, saveMedia }

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -37,47 +37,77 @@ const scrapEvent = async function (req: Request, res: Response) {
     
     log.info(`caching objects ...`);
     for (let event of result) {
-        if (await findEvent(event.externalId)) {
-            log.warn(`Oops: duplicate on ${event.externalId}`);
-            // FIXME: do an update
-            continue;
+
+        let cachedEvent = await getEvent(event.externalId);
+        if (cachedEvent) {
+            log.debug(`existing event found, updating data for ${event.externalId}`);
+
+            await geocodeAddress(sourceId, event);
+            await cachedEvent.update({
+                $set: {
+                    name: event.name,
+                    description: event.description,
+
+                    teaserText: event.teaserText,
+                    teaserMedia: event.teaserMedia,
+                    teaserFreeform: event.teaserFreeform,
+
+                    placeLattitude: event.placeLattitude,
+                    placeLongitude: event.placeLongitude,
+                    placeFreeform: event.placeFreeform,
+
+                    budgetMin: event.budgetMin,
+                    budgetMax: event.budgetMax,
+                    budgetCurrency: event.budgetCurrency,
+                    budgetFreeform: event.budgetFreeform,
+
+                    datetimeFrom: event.datetimeFrom.toISOString(),
+                    datetimeTo: event.datetimeTo.toISOString(),
+                    datetimeFreeform: event.datetimeFreeform,
+
+                    category: event.category,
+                    categoryFreeform: event.categoryFreeform,
+
+                    size: event.size,
+                    sizeFreeform: event.sizeFreeform,
+                }
+            });
+
+        } else {
+            await geocodeAddress(sourceId, event);
+
+            await eaCache.events.insert({
+                id: event.externalId,
+                externalId: event.externalId,
+                originId: event.originId,
+                originUrl: event.originUrl,
+                name: event.name,
+                description: event.description,
+
+                teaserText: event.teaserText,
+                teaserMedia: event.teaserMedia,
+                teaserFreeform: event.teaserFreeform,
+
+                placeLattitude: event.placeLattitude,
+                placeLongitude: event.placeLongitude,
+                placeFreeform: event.placeFreeform,
+
+                budgetMin: event.budgetMin,
+                budgetMax: event.budgetMax,
+                budgetCurrency: event.budgetCurrency,
+                budgetFreeform: event.budgetFreeform,
+
+                datetimeFrom: event.datetimeFrom.toISOString(),
+                datetimeTo: event.datetimeTo.toISOString(),
+                datetimeFreeform: event.datetimeFreeform,
+
+                category: event.category,
+                categoryFreeform: event.categoryFreeform,
+
+                size: event.size,
+                sizeFreeform: event.sizeFreeform,
+            });
         }
-
-        await geocodeAddress(sourceId, event);
-        
-        await eaCache.events.insert({
-            // FIXME: shoud be something, not 0
-            id: event.externalId,
-            externalId: event.externalId,
-            originId: event.originId,
-            originUrl: event.originUrl,
-            name: event.name,
-            description: event.description,
-
-            teaserText: event.teaserText,
-            teaserMedia: event.teaserMedia,
-            teaserFreeform: event.teaserFreeform,
-
-            placeLattitude: event.placeLattitude,
-            placeLongitude: event.placeLongitude,
-            placeFreeform: event.placeFreeform,
-
-            budgetMin: event.budgetMin,
-            budgetMax: event.budgetMax,
-            budgetCurrency: event.budgetCurrency,
-            budgetFreeform: event.budgetFreeform,
-
-            datetimeFrom: event.datetimeFrom.toISOString(),
-            datetimeTo: event.datetimeTo.toISOString(),
-            datetimeFreeform: event.datetimeFreeform,
-
-            category: event.category,
-            categoryFreeform: event.categoryFreeform,
-
-            size: event.size,
-            sizeFreeform: event.sizeFreeform,
-        });
-
     }
 
     res.status(200)
@@ -93,6 +123,17 @@ const findEvent = async function (externalId) {
         }
     }).exec();
     return result.length > 0 ? true : false;
+}
+
+const getEvent = async function (externalId) {
+    let result = await eaCache.events.find({
+        selector: {
+            "externalId": {
+                $eq: externalId
+            }
+        }
+    }).exec();
+    return result.length > 0 ? result[0] : undefined;
 }
 
 const searchEvent = async function (req: Request, res: Response) {
@@ -294,11 +335,19 @@ const saveMedia = async function (url: string) {
     const buffer = Buffer.from( await mediaBlob.arrayBuffer() );
 
     const fileExtension = url.split('.').pop();
-    const fileName = `${config.mediaStoragePath}/${md5(url)}.${fileExtension}`.toLocaleLowerCase();
+    const fileName = `${md5(url)}.${fileExtension}`.toLocaleLowerCase();
+    const filePath = `${config.mediaStoragePath}/${fileName}`;
 
-    fs.writeFileSync(fileName, buffer);
+    // only download if the same path didn't exist locally
+    // FIXME: compate last-modified header and local timestamp
+    fs.access(filePath, fs.constants.R_OK, (err) => {
+        if (err) {
+            fs.writeFileSync(`${config.mediaStoragePath}/${fileName}`, buffer)
+            log.debug(`media saved: ${url} ${mediaBlob.type} (${mediaBlob.size} bytes)`);
+        }
+    })
 
-    return fileName;
+    return `/medias/${fileName}`;
 }
 
 export { scrapEvent, searchEvent, getEventById, getSearchHits, saveMedia }

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -325,29 +325,38 @@ const getSearchHits = async function (req: Request, resp: Response) {
 // save the media behind a given url locally and return the "local url" (or undefined if error)
 // the return path can be used as the new filepath below express static "/media"
 const saveMedia = async function (url: string) {
-    const mediaResp = await fetch(url);
-    if (mediaResp.status != 200) {
-        log.warn(`unable to fetch media: ${url}`);
-        return undefined;
-    }
-
-    const mediaBlob = await mediaResp.blob();
-    const buffer = Buffer.from( await mediaBlob.arrayBuffer() );
-
-    const fileExtension = url.split('.').pop();
-    const fileName = `${md5(url)}.${fileExtension}`.toLocaleLowerCase();
-    const filePath = `${config.mediaStoragePath}/${fileName}`;
-
-    // only download if the same path didn't exist locally
-    // FIXME: compate last-modified header and local timestamp
-    fs.access(filePath, fs.constants.R_OK, (err) => {
-        if (err) {
-            fs.writeFileSync(`${config.mediaStoragePath}/${fileName}`, buffer)
-            log.debug(`media saved: ${url} ${mediaBlob.type} (${mediaBlob.size} bytes)`);
+    
+    try {
+        const mediaResp = await fetch(url);
+        
+        if (mediaResp.status != 200) {
+            log.warn(`unable to fetch media: ${url}`);
+            return undefined;
         }
-    })
+        
+        const mediaBlob = await mediaResp.blob();
+        const buffer = Buffer.from( await mediaBlob.arrayBuffer() );
+        
+        const fileExtension = url.split('.').pop();
+        const fileName = `${md5(url)}.${fileExtension}`.toLocaleLowerCase();
+        const filePath = `${config.mediaStoragePath}/${fileName}`;
+        
+        // only download if the same path didn't exist locally
+        // FIXME: compate last-modified header and local timestamp
+        fs.access(filePath, fs.constants.R_OK, (err) => {
+            if (err) {
+                fs.writeFileSync(`${config.mediaStoragePath}/${fileName}`, buffer)
+                log.debug(`media saved: ${url} ${mediaBlob.type} (${mediaBlob.size} bytes)`);
+            }
+        })
+        
+        return `/media/${fileName}`;
 
-    return `/media/${fileName}`;
+    } catch (e) {
+        // FIXME: put some default here in case the fetch is unable to connect/fails
+        return "";
+    }
 }
+
 
 export { scrapEvent, searchEvent, getEventById, getSearchHits, saveMedia }

--- a/server/src/middlewares/apiGateway.ts
+++ b/server/src/middlewares/apiGateway.ts
@@ -2,6 +2,7 @@ import { addRxPlugin, RxReplicationPullStreamItem } from 'rxdb/plugins/core';
 import { RxDBDevModePlugin } from 'rxdb/plugins/dev-mode';
 import { createRxDatabase } from 'rxdb';
 import { getRxStorageMemory } from 'rxdb/plugins/storage-memory';
+import { RxDBUpdatePlugin } from 'rxdb/plugins/update';
 import { wrappedValidateAjvStorage } from 'rxdb/plugins/validate-ajv';
 import { getAjv } from 'rxdb/plugins/validate-ajv';
 import { replicateRxCollection } from 'rxdb/plugins/replication';
@@ -11,7 +12,7 @@ import { doRestore } from '../utils/persistence.js';
 let eaCache;
 
 addRxPlugin(RxDBDevModePlugin);
-
+addRxPlugin(RxDBUpdatePlugin);
 const restoreEventStream$ = new Subject<RxReplicationPullStreamItem<any, any>>();
 
 async function initCache() {

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -81,7 +81,7 @@ const config: Config = {
     // in all case, the latest file or record will be restored at startup
     // backupTarget: "file:../backups",
     backupTarget: "sql:backups",
-    mediaStoragePath: "../medias"
+    mediaStoragePath: "../media"
 }
 
 // some sanity checks

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -15,6 +15,7 @@ interface Config {
     nodeEnv: string;
     backupSchedule: string;
     backupTarget: string;
+    mediaStoragePath: string;
     sources: Array<EventSourceConfigType>;
 }
 
@@ -69,6 +70,7 @@ let _source: Array<EventSourceConfigType> = [
     }
 ]
 
+// paths are relative to SERVER folder
 const config: Config = {
     port: Number(process.env.PORT) || 3000,
     nodeEnv: process.env.NODE_ENV || "development",
@@ -79,6 +81,7 @@ const config: Config = {
     // in all case, the latest file or record will be restored at startup
     // backupTarget: "file:../backups",
     backupTarget: "sql:backups",
+    mediaStoragePath: "../medias"
 }
 
 // some sanity checks


### PR DESCRIPTION
# ✅ Resolves #99 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

this feature allow a given scraping implementation to get a local copy of a media url, and serve it instead of hotlinking the source.
if the download is successfull, the teaserMedia field of the event will points to a absolute path served by the local express static config "/medias"
if not, the original (external) link will stay in the event object

### 🧪 Testing instructions

- create locally the folder /medias in the project root
- scrap japancheapo
- see if the media appaears in the folders as md5 hashs + ext (also infos in the logs)
- go get one of the event (ex: http://127.0.0.1:3000/api/events/bd35e81d8019486471107fcb500d2e38)
- see that the teaserMedia is now pointing to a local url that return the actual image

! beware that before deployoing to render, the /medias locapath must be mounted to an external persistant disk

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
