### PR TITLE
fix: media storage path can be changed by setting MEDIA_STORAGE_PATH env var.

### DIFF
--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -81,7 +81,7 @@ const config: Config = {
     // in all case, the latest file or record will be restored at startup
     // backupTarget: "file:../backups",
     backupTarget: "sql:backups",
-    mediaStoragePath: "../media"
+    mediaStoragePath: process.env.MEDIA_STORAGE_PATH || "../media"
 }
 
 // some sanity checks


### PR DESCRIPTION
# ✅ Resolves #99 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

set MEDIA_STORAGE_PATH in the .env to points to the local image cache folder (ex: /media)

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
