### PR TITLE
fix: handle weird image url without extension

### DIFF
--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -338,9 +338,9 @@ const saveMedia = async function (url: string) {
         const buffer = Buffer.from( await mediaBlob.arrayBuffer() );
         
         let fileExtension = "blob";
-        let lastUrlPart = url.split('/').pop();
-        if (url.indexOf('.') > 0 && url.indexOf('/') < 0) {
-            fileExtension = url.split('.').pop() || "blob";
+        let lastUrlPart = url.split('/').pop() || "";
+        if (lastUrlPart.indexOf('.') > 0 && lastUrlPart.indexOf('/') < 0) {
+            fileExtension = lastUrlPart.split('.').pop() || "blob";
         }
 
         const fileName = `${md5(url)}.${fileExtension}`.toLocaleLowerCase();


### PR DESCRIPTION
# ✅ Resolves #99 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

in some cases, the originalUrl is weird enough that we are unable to get the extension without breaking the local path
handle that case by falling back to .blob extension if tnothing better can be extracted

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
