### PR TITLE
Fix/close calendar on selection justin

### DIFF
--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -198,7 +198,6 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
           selectedDates={selectedDates}
           setSelectedDates={setSelectedDates}
         />
-        <input type="date" />
       </div>
 
       {/* Search type */}

--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -98,6 +98,12 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
     if (!search && !category && !location && !price && !selectedDates) {
       alert("Please enter a search term, price, category, dates, or location!");
       return;
+    } else if (
+      selectedDates !== undefined &&
+      selectedDates[0] > selectedDates[1]
+    ) {
+      alert("Start date must come before end date.");
+      return;
     } else {
       getEvents();
     }
@@ -192,6 +198,7 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
           selectedDates={selectedDates}
           setSelectedDates={setSelectedDates}
         />
+        <input type="date" />
       </div>
 
       {/* Search type */}

--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -98,6 +98,7 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
       selectedDates[0] > selectedDates[1]
     ) {
       alert("Start date must come before end date.");
+      setSelectedDates(undefined);
       return;
     } else {
       getEvents();

--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -206,9 +206,7 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
             onChange={toggleSearchLocType}
             disabled={userRefused}
           />
-          {locSearchType === "latLong"
-            ? "Search near me"
-            : "Search by prefecture"}
+          {locSearchType === "latLong" ? "km from me" : "Search by prefecture"}
         </label>
         {/* Search by prefecture */}
         <select
@@ -233,7 +231,7 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
           className="relative w-full flex flex-row items-center gap-2"
           hidden={locSearchType === "prefecture"}
         >
-          <label htmlFor="search-radius">Km from me</label>
+          {/* <label htmlFor="search-radius">Km from me</label> */}
           <input
             type="range"
             min={0}


### PR DESCRIPTION
# ✅ Resolves #[144]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected

## For assignee

### 🔧 What changed

Users can no longer select end dates that come before the start date on the date picker.

### 🧪 Testing instructions

- Select an end date that comes before the start date and confirm that the alert blocks the submission and clears the input.
- Select an date that comes after the start date and confirm that the submission goes through normally.

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
