### PR TITLE
feat: allow site-wide restriction of country available (but still indexed)

### DIFF
--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -234,7 +234,9 @@ const searchEvent = async function (req: Request, res: Response) {
                     { budgetMax: { $lt: Number(budgetMax) } },
 
                     { datetimeFrom: { $gt: datetimeFrom } },
-                    { datetimeFrom: { $lt: datetimeTo } }
+                    { datetimeFrom: { $lt: datetimeTo } },
+
+                    { placeCountry: { $in: config.includeOnlyCountry } }
                 ]
             }
         }).exec().then( (documents : Array<RxDocument>) => {
@@ -289,9 +291,12 @@ const getEventById = async function (req: Request, res: Response) {
     let externalId = req.params.eventId;
     let result = await eaCache.events.find({
         selector: {
-            "externalId": {
-                $eq: externalId
-            }
+            $and: [
+                { "externalId": {
+                    $eq: externalId,
+                } },
+                { "placeCountry": { $in: config.includeOnlyCountry } }
+            ]
         }
     }).exec();
 
@@ -314,7 +319,10 @@ const getSearchHits = async function (req: Request, resp: Response) {
 
     let result = await eaCache.events.find({
         selector: {
-            name: { $regex: '.*', $options: 'i' },
+            $and: [
+                { name: { $regex: '.*', $options: 'i' } },
+                { placeCountry: { $in: config.includeOnlyCountry } }
+            ]
         }
     }).exec();
     

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -18,6 +18,7 @@ interface Config {
     backupSchedule: string;
     backupTarget: string;
     mediaStoragePath: string;
+    includeOnlyCountry: string[];
     sources: Array<EventSourceConfigType>;
 }
 
@@ -105,7 +106,8 @@ const config: Config = {
     // in all case, the latest file or record will be restored at startup
     // backupTarget: "file:../backups",
     backupTarget: "sql:backups",
-    mediaStoragePath: process.env.MEDIA_STORAGE_PATH || "../media"
+    mediaStoragePath: process.env.MEDIA_STORAGE_PATH || "../media",
+    includeOnlyCountry: ['Japan']
 }
 
 // some sanity checks


### PR DESCRIPTION
# ✅ Resolves #151 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

a new config option allows to filterout all but a list of predefined country
! case sensitive settings. the name must be the one returned by reverse geocoding from OSM.

### 🧪 Testing instructions

try to find some events outside of japan (like one in europe from allsportsdb)
they should not be displayed

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
