### PR TITLE
fix: use fallback ima if the original img fails to render

### DIFF
--- a/client/src/components/EventPreviewCard.tsx
+++ b/client/src/components/EventPreviewCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { categoryImages } from "../assets/categoryImages";
+import { getDefaultImg } from "../utils/getDefaultImg";
 
 interface EventPreviewCardProps {
   id: string;
@@ -10,7 +11,7 @@ interface EventPreviewCardProps {
   date: string;
   price: number;
   link: string;
-  imageUrl?: string; 
+  imageUrl?: string;
 }
 
 export default function EventPreviewCard({
@@ -33,7 +34,7 @@ export default function EventPreviewCard({
 
   const imageSrc =
     imageUrl && imageUrl.trim() !== ""
-      ? (server + "/.." + imageUrl)
+      ? server + "/.." + imageUrl
       : fallbackImage;
 
   return (
@@ -45,6 +46,7 @@ export default function EventPreviewCard({
       <div className="w-42 h-42 flex-shrink-0">
         <img
           src={imageSrc}
+          onError={(e) => getDefaultImg(e, fallbackImage)}
           alt={name}
           className="w-full h-full object-cover"
           loading="lazy"

--- a/client/src/utils/getDefaultImg.ts
+++ b/client/src/utils/getDefaultImg.ts
@@ -1,0 +1,9 @@
+import type { SyntheticEvent } from "react";
+
+export function getDefaultImg(
+  event: SyntheticEvent<HTMLImageElement, Event>,
+  defaultImg: string
+): void {
+  const target = event.target as HTMLImageElement;
+  target.src = defaultImg;
+}


### PR DESCRIPTION
This uses the React Typescript implementation of the onerror attirbute.

# ✅ Resolves #[150]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

Images now use the `onError` attribute to get the fallback image in case the original image fails to render for any reason.

### 🧪 Testing instructions

Make a search and confirm that no images are broken.

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
