### PR TITLE
fix: meta count now filder out events older than now()

### DIFF
--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -312,7 +312,6 @@ const getSearchHits = async function (req: Request, resp: Response) {
     
     log.debug(`hits for ${requestedIndex}`);
 
-    log.debug(moment().startOf('day').toISOString());
     let result = await eaCache.events.find({
         selector: {
             $and: [

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -314,7 +314,10 @@ const getSearchHits = async function (req: Request, resp: Response) {
 
     let result = await eaCache.events.find({
         selector: {
-            name: { $regex: '.*', $options: 'i' },
+            $and: [
+                { name: { $regex: '.*', $options: 'i' } },
+                { datetimeFrom: { $gt: moment().toISOString() }}
+            ]
         }
     }).exec();
     

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -312,11 +312,12 @@ const getSearchHits = async function (req: Request, resp: Response) {
     
     log.debug(`hits for ${requestedIndex}`);
 
+    log.debug(moment().startOf('day').toISOString());
     let result = await eaCache.events.find({
         selector: {
             $and: [
                 { name: { $regex: '.*', $options: 'i' } },
-                { datetimeFrom: { $gt: moment().toISOString() }}
+                { datetimeFrom: { $gt: moment().startOf('day').toISOString() }}
             ]
         }
     }).exec();


### PR DESCRIPTION
# ✅ Resolves #153 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

before the meta call computed the #of events without filtering the "past" events

### 🧪 Testing instructions

now, meta include all events starting from today+, past one are excluded from the count

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
