### PR TITLE
Fix/meta count wrong because of undefined

### DIFF
--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import config from '../utils/config.js'
 import { log } from '../utils/logger.js'
-import { ES_SEARCH_IN_CACHE, datetimeRangeEnum, EventType, Event } from "../models/Event.js"
+import { ES_SEARCH_IN_CACHE, datetimeRangeEnum, EventType, Event, EventCategoryEnum } from "../models/Event.js"
 import { LocalEventSource } from './LocalEventSource.js';
 import { eaCache } from '../middlewares/apiGateway.js';
 import moment from 'moment';
@@ -309,7 +309,8 @@ const getEventById = async function (req: Request, res: Response) {
 const getSearchHits = async function (req: Request, resp: Response) {
     let requestedIndex = req.query.key || "";
     let hits: object = {};
-    
+    hits[EventCategoryEnum.OTHER] = 0;
+
     log.debug(`hits for ${requestedIndex}`);
 
     let result = await eaCache.events.find({
@@ -327,11 +328,12 @@ const getSearchHits = async function (req: Request, resp: Response) {
             let eventCategory = event[requestedIndex.toString()];
             let eventCategoryFreeform = event.eventCategoryFreeform;
 
-            if (eventCategory === "") {
-                hits["unsorted"]++ || 0;
+            if (!eventCategory) {
+                hits[EventCategoryEnum.OTHER]++;
+
             } else {
                 if (hits[eventCategory] === undefined) hits[eventCategory] = 0;
-                hits[eventCategory]++ || 0;
+                hits[eventCategory]++;
             }
         }
 


### PR DESCRIPTION
# ✅ Resolves: none. proactive fix.

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

- in the meta call, there was Other and 'unsorted' (= undefined). that's misleading in the UI. just use 'Other' for both.
- undefined count was lost up to the first empty string for the index value. that gave different result beteen total and individual entries.

### 🧪 Testing instructions

the total display in the hero must be equal of the total all each category.
same for prefectures

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
