### PR TITLE
fix: added call to locally cache the teaserMedia

### DIFF
--- a/server/src/controllers/ArisugawaParkEventSource.ts
+++ b/server/src/controllers/ArisugawaParkEventSource.ts
@@ -94,6 +94,9 @@ class ArisugawaParkEventSource extends DefaultEventSource {
             anEvent.placeFreeform = eventDetail.placeFreeform;
 
             anEvent.teaserMedia = eventDetail.teaserMedia;
+            let localUrl = await ec.saveMedia(anEvent.teaserMedia);
+            if (localUrl) { anEvent.teaserMedia = localUrl };
+
             anEvent.teaserText = eventDetail.teaserText;
 
             anEvent.category = EventCategoryEnum.FAMILY;


### PR DESCRIPTION
# ✅ Resolves #[Issue number]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

before: teaserMedia was hotlinked to source website
after: teaserMedia image is cached locally

### 🧪 Testing instructions

if you reindex arisugawapark, you will see in the log entries about saving files locally
also, the number of files will be higher in /media
also, from the UI, the link to an image will points to the same server as the rest of the app, in /media

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
