### PR TITLE
fix: change location search to km instead of meters

### DIFF
--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -69,10 +69,17 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
 
       let query = `${api}/events?name=${search}&category=${category}&budgetMax=${price}&datetimeFrom=${from}&datetimeTo=${to}&`;
       if (locSearchType === "latLong") {
-        query += `placeDistanceRange=${searchRadius}&browserLat=${latitude}&browserLong=${longitude}`;
+        query += `placeDistanceRange=${
+          searchRadius * 1000
+        }&browserLat=${latitude}&browserLong=${longitude}`;
       } else {
         query += `placeProvince=${prefecture}`;
       }
+
+      console.log(query);
+
+      console.log("lat:", latitude);
+      console.log("long:", longitude);
 
       const response = await fetch(query);
       if (!response.ok) {
@@ -81,6 +88,8 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
       }
       const data = await response.json();
       setDisplayHero(false);
+      console.log(data);
+
       setEvents(data);
     } catch (error) {
       console.error(error);

--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -76,11 +76,6 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
         query += `placeProvince=${prefecture}`;
       }
 
-      console.log(query);
-
-      console.log("lat:", latitude);
-      console.log("long:", longitude);
-
       const response = await fetch(query);
       if (!response.ok) {
         console.error(response);
@@ -88,7 +83,6 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
       }
       const data = await response.json();
       setDisplayHero(false);
-      console.log(data);
 
       setEvents(data);
     } catch (error) {

--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -83,7 +83,6 @@ export default function EventFilters({ setDisplayHero }: EventFiltersProps) {
       }
       const data = await response.json();
       setDisplayHero(false);
-
       setEvents(data);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
The API expects the search radius value to be in meters, so the searchRadius value on the client is multiplied by 1000 when sent with the query string.

# ✅ Resolves #[170]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

Seach "km from me" should return meaningful results.

### 🧪 Testing instructions

Use the "km from me" switch and search. 

## For person submitting the PR

## Checklist

- [x] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
