### PR TITLE
Date offset fix

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Event Curator</title>
+    <title>Japan Events</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/EventDateGroupCard.tsx
+++ b/client/src/components/EventDateGroupCard.tsx
@@ -15,7 +15,6 @@ export default function EventDateGroupCard({
     <>
       <h2 className="text-3xl font-bold no-underline">{date}</h2>
       {events.map((event) => (
-        // const fmtDate = moment(event.datetimeFrom).format("LL");
         <EventPreviewCard
           key={event.externalId}
           id={event.externalId}
@@ -23,8 +22,10 @@ export default function EventDateGroupCard({
           category={event.category}
           categoryFreeform={event.categoryFreeform}
           location={event.placeFreeform}
-          dateFrom={moment(event.datetimeFrom).format("LL")}
-          dateTo={moment(event.datetimeTo).format("LL")}
+          dateFrom={moment(event.datetimeFrom)
+            .subtract(9, "hours")
+            .format("LL")}
+          dateTo={moment(event.datetimeTo).subtract(9, "hours").format("LL")}
           price={event.budgetMax}
           link={event.originUrl}
           imageUrl={event.teaserMedia}

--- a/client/src/components/EventInfo.tsx
+++ b/client/src/components/EventInfo.tsx
@@ -1,13 +1,9 @@
 import FormattedPrice from "../components/FormattedPrice";
 import type { FullEventType } from "../types";
+import fixTimeOffset from "../utils/fixTimeOffSet";
 
-export default function EventInfo({
-  event,
-}: {
-  event: FullEventType;
-}) {
-  const startDate = event.datetimeFrom ? new Date(event.datetimeFrom) : null;
-  const endDate = event.datetimeTo ? new Date(event.datetimeTo) : null;
+export default function EventInfo({ event }: { event: FullEventType }) {
+  const { startDate, endDate, startTime, endTime } = fixTimeOffset(event);
 
   return (
     <div className="space-y-2 text-gray-700 text-sm mb-6">
@@ -19,18 +15,11 @@ export default function EventInfo({
       </p>
       <p>
         <b>Date:&nbsp;</b>
-        {startDate ? startDate.toLocaleDateString() : "-"} —{" "}
-        {endDate ? endDate.toLocaleDateString() : "-"}
+        {startDate !== endDate ? `${startDate} — ${endDate}` : startDate}
       </p>
       <p>
         <b>Time:&nbsp;</b>
-        {startDate
-          ? startDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-          : "-"}
-        {" — "}
-        {endDate
-          ? endDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-          : "-"}
+        {`${startTime} — ${endTime}`}
       </p>
       <p>
         <b>Price:</b> <FormattedPrice price={event.budgetMin} />
@@ -46,7 +35,12 @@ export default function EventInfo({
       {event.website && (
         <p>
           <b>Website:</b>{" "}
-          <a href={event.website} target="_blank" rel="noopener noreferrer" className="text-blue-700 underline">
+          <a
+            href={event.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-700 underline"
+          >
             {event.website}
           </a>
         </p>

--- a/client/src/components/EventInfo.tsx
+++ b/client/src/components/EventInfo.tsx
@@ -4,6 +4,7 @@ import fixTimeOffset from "../utils/fixTimeOffSet";
 
 export default function EventInfo({ event }: { event: FullEventType }) {
   const { startDate, endDate, startTime, endTime } = fixTimeOffset(event);
+  console.log(startDate, endDate);
 
   return (
     <div className="space-y-2 text-gray-700 text-sm mb-6">

--- a/client/src/components/EventSection.tsx
+++ b/client/src/components/EventSection.tsx
@@ -31,7 +31,9 @@ export default function EventSection({ searchQuery }: Props) {
       events: [],
     };
     for (const event of filteredEvents) {
-      const fmtDate = moment(event.datetimeFrom).format("LL");
+      const fmtDate = moment(event.datetimeFrom)
+        .subtract(9, "hours")
+        .format("LL");
       if (fmtDate === group.date) {
         group.events.push(event);
       }

--- a/client/src/components/EventSection.tsx
+++ b/client/src/components/EventSection.tsx
@@ -13,10 +13,13 @@ export default function EventSection({ searchQuery }: Props) {
   const { events } = useContext(EventContext);
 
   // Filter events if searchQuery is present
+  // TODO: Delete this? I don't see the point of this.
   const filteredEvents = searchQuery
-    ? events.filter((event: FullEventType) =>
-        event.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        (event.description && event.description.toLowerCase().includes(searchQuery.toLowerCase()))
+    ? events.filter(
+        (event: FullEventType) =>
+          event.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          (event.description &&
+            event.description.toLowerCase().includes(searchQuery.toLowerCase()))
       )
     : events;
 

--- a/client/src/components/Hero.tsx
+++ b/client/src/components/Hero.tsx
@@ -37,7 +37,7 @@ export default function Hero() {
 
       <div className="relative z-10 text-white text-center px-4">
         <h1 className="text-6xl md:text-8xl font-extrabold drop-shadow mb-3 font-sans tracking-tight text-primary-content">
-          Events in Japan
+          Japan Events
         </h1>
         <p className="text-2xl md:text-4xl drop-shadow mb-3 font-sans tracking-tight text-primary-content">
           Search from {eventTotal} Festivals, Concerts, Sports Events & More!

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -344,7 +344,7 @@ export default function Navbar() {
           <Link to="/" className="flex items-center space-x-2">
             <img src={eventIcon} alt="logo" className="h-6 w-6" />
             <span className="text-lg font-bold text-blue-700">
-              Japan-Events
+              Japan Events
             </span>
           </Link>
         </div>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -49,7 +49,11 @@ export default function Navbar() {
     setError(null);
     setLoading(true);
     try {
-      const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+      const userCredential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
       setUser(userCredential.user);
       setEmail("");
       setPassword("");
@@ -66,7 +70,11 @@ export default function Navbar() {
     setError(null);
     setLoading(true);
     try {
-      const userCredential = await signInWithEmailAndPassword(auth, email, password);
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
       setUser(userCredential.user);
       setEmail("");
       setPassword("");
@@ -116,12 +124,18 @@ export default function Navbar() {
   const MobileAuthButtons = (
     <>
       <li>
-        <button className="btn btn-primary btn-sm w-full mb-2" onClick={() => setShowLogin(true)}>
+        <button
+          className="btn btn-primary btn-sm w-full mb-2"
+          onClick={() => setShowLogin(true)}
+        >
           Sign In
         </button>
       </li>
       <li>
-        <button className="btn btn-outline btn-sm w-full" onClick={() => setShowRegister(true)}>
+        <button
+          className="btn btn-outline btn-sm w-full"
+          onClick={() => setShowRegister(true)}
+        >
           Register
         </button>
       </li>
@@ -130,7 +144,9 @@ export default function Navbar() {
 
   async function fetchEventsByName(name: string) {
     try {
-      const response = await fetch(`${api}/events?name=${encodeURIComponent(name)}`);
+      const response = await fetch(
+        `${api}/events?name=${encodeURIComponent(name)}`
+      );
       if (!response.ok) {
         setError("Failed to fetch events.");
         return;
@@ -175,8 +191,8 @@ export default function Navbar() {
     if (
       location.pathname === "/" &&
       location.state &&
-      (typeof location.state === "object") &&
-      ("hideHero" in location.state)
+      typeof location.state === "object" &&
+      "hideHero" in location.state
     ) {
       setTimeout(() => {
         const hero = document.getElementById("hero-section");
@@ -191,8 +207,6 @@ export default function Navbar() {
     // eslint-disable-next-line
   }, [location.pathname]);
 
-  
-
   return (
     <nav className="bg-base-100 shadow-md border-b border-blue-100 w-full">
       {/* Desktop Navbar */}
@@ -202,7 +216,7 @@ export default function Navbar() {
           <Link to="/" className="flex items-center gap-3">
             <img src={eventIcon} alt="logo" className="h-20 w-20" />
             <span className="text-2xl font-bold text-blue-700 tracking-wide">
-              Japan-Events
+              Japan Events
             </span>
           </Link>
         </div>
@@ -235,10 +249,16 @@ export default function Navbar() {
             />
           ) : (
             <>
-              <button className="btn btn-outline btn-sm" onClick={() => setShowRegister(true)}>
+              <button
+                className="btn btn-outline btn-sm"
+                onClick={() => setShowRegister(true)}
+              >
                 Register
               </button>
-              <button className="btn btn-primary btn-sm" onClick={() => setShowLogin(true)}>
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => setShowLogin(true)}
+              >
                 Sign In
               </button>
             </>
@@ -250,11 +270,25 @@ export default function Navbar() {
       <div className="md:hidden flex items-center justify-between px-4 h-14 w-full">
         <div className="dropdown">
           <label tabIndex={0} className="btn btn-ghost btn-circle">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
             </svg>
           </label>
-          <ul tabIndex={0} className="dropdown-content menu p-3 shadow bg-white rounded-box w-64 mt-2 border border-blue-100 z-50">
+          <ul
+            tabIndex={0}
+            className="dropdown-content menu p-3 shadow bg-white rounded-box w-64 mt-2 border border-blue-100 z-50"
+          >
             {user ? (
               <>
                 <li className="flex flex-col items-center justify-center gap-2 py-2">
@@ -270,22 +304,33 @@ export default function Navbar() {
                       />
                     </div>
                   </div>
-                  <span className="text-xs">{user.displayName || user.email}</span>
+                  <span className="text-xs">
+                    {user.displayName || user.email}
+                  </span>
                 </li>
                 {!isGoogleUser && (
                   <li>
-                    <button className="btn btn-outline btn-sm mt-2 w-full" onClick={() => navigate("/profile")}>
+                    <button
+                      className="btn btn-outline btn-sm mt-2 w-full"
+                      onClick={() => navigate("/profile")}
+                    >
                       Profile Settings
                     </button>
                   </li>
                 )}
                 <li>
-                  <Link to="/timeline" className="btn btn-outline btn-sm w-full mt-2">
+                  <Link
+                    to="/timeline"
+                    className="btn btn-outline btn-sm w-full mt-2"
+                  >
                     My Event Timeline
                   </Link>
                 </li>
                 <li>
-                  <button className="btn btn-outline btn-sm mt-2 w-full" onClick={handleLogout}>
+                  <button
+                    className="btn btn-outline btn-sm mt-2 w-full"
+                    onClick={handleLogout}
+                  >
                     Logout
                   </button>
                 </li>
@@ -353,8 +398,16 @@ export default function Navbar() {
         />
       )}
       {/* Alerts */}
-      {error && <div className="fixed top-16 right-4 alert alert-error shadow-lg">{error}</div>}
-      {loading && <div className="fixed top-16 right-4 alert alert-info shadow-lg">Loading...</div>}
+      {error && (
+        <div className="fixed top-16 right-4 alert alert-error shadow-lg">
+          {error}
+        </div>
+      )}
+      {loading && (
+        <div className="fixed top-16 right-4 alert alert-info shadow-lg">
+          Loading...
+        </div>
+      )}
     </nav>
   );
 }

--- a/client/src/components/WeekCalendarView.tsx
+++ b/client/src/components/WeekCalendarView.tsx
@@ -15,27 +15,41 @@ type WeekCalendarViewProps = {
 };
 
 function getBarSpanIndices(ev: FullEventType, weekDates: Date[]) {
-  const start = moment(ev.datetimeFrom).startOf('day');
-  const end = moment(ev.datetimeTo).endOf('day');
+  const start = moment(ev.datetimeFrom).startOf("day");
+  const end = moment(ev.datetimeTo).endOf("day");
   const indices = weekDates
     .map((d, i) => {
-        let currentDate = moment(d);
-        return currentDate.startOf('day').isSameOrAfter(start) && currentDate.endOf('day').isSameOrBefore(end) ? i : null
-      }
-    )
-    .filter(i => i !== null) as number[];
+      let currentDate = moment(d);
+      return currentDate.startOf("day").isSameOrAfter(start) &&
+        currentDate.endOf("day").isSameOrBefore(end)
+        ? i
+        : null;
+    })
+    .filter((i) => i !== null) as number[];
 
-    return indices;
+  return indices;
 }
 
 const ArrowLeft = (props: React.SVGProps<SVGSVGElement>) => (
   <svg width={32} height={32} fill="none" viewBox="0 0 24 24" {...props}>
-    <path d="M15 19l-7-7 7-7" stroke="#2761da" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"/>
+    <path
+      d="M15 19l-7-7 7-7"
+      stroke="#2761da"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 );
 const ArrowRight = (props: React.SVGProps<SVGSVGElement>) => (
   <svg width={32} height={32} fill="none" viewBox="0 0 24 24" {...props}>
-    <path d="M9 5l7 7-7 7" stroke="#2761da" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"/>
+    <path
+      d="M9 5l7 7-7 7"
+      stroke="#2761da"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 );
 
@@ -66,17 +80,17 @@ export default function WeekCalendarView({
   }
 
   // Collect multi-day events that overlap this week
- const multiDayEvents: FullEventType[] = allEventsDedup.filter(ev => {
-  if (!ev.datetimeTo) return false;
-  const start = moment(ev.datetimeFrom).startOf('day');
-  const end = moment(ev.datetimeTo).startOf('day');
-  // Only include if end is after start (at least 1 day apart)
-  return (
-    end.diff(start, 'days') >= 1 &&
-    end.toDate() >= weekStart &&
-    start.toDate() <= weekEnd
-  );
-});
+  const multiDayEvents: FullEventType[] = allEventsDedup.filter((ev) => {
+    if (!ev.datetimeTo) return false;
+    const start = moment(ev.datetimeFrom).startOf("day");
+    const end = moment(ev.datetimeTo).startOf("day");
+    // Only include if end is after start (at least 1 day apart)
+    return (
+      end.diff(start, "days") >= 1 &&
+      end.toDate() >= weekStart &&
+      start.toDate() <= weekEnd
+    );
+  });
 
   // Calculate height for the bars wrapper
   const eventBarHeight = 26;
@@ -114,7 +128,7 @@ export default function WeekCalendarView({
           style={{
             height: barsTotalHeight,
             marginBottom: barsTotalHeight > 0 ? "8px" : "0",
-            transition: "height 0.2s cubic-bezier(.42,0,.58,1)"
+            transition: "height 0.2s cubic-bezier(.42,0,.58,1)",
           }}
         >
           {multiDayEvents.map((ev, idx) => {
@@ -144,9 +158,11 @@ export default function WeekCalendarView({
                   cursor: "pointer",
                   pointerEvents: "auto",
                   zIndex: 5,
-                  transition: "top 0.2s"
+                  transition: "top 0.2s",
                 }}
-                onClick={() => window.location.assign(`/event/${ev.externalId}`)}
+                onClick={() =>
+                  window.location.assign(`/event/${ev.externalId}`)
+                }
                 title={ev.name}
               >
                 <span className="truncate">{ev.name}</span>
@@ -157,8 +173,11 @@ export default function WeekCalendarView({
       )}
 
       {/* Weekday header (always directly below multi-day bars) */}
-      <div className="w-full flex flex-row gap-8 px-8" style={{ marginBottom: "0.5rem" }}>
-        {weekDates.map(date => (
+      <div
+        className="w-full flex flex-row gap-8 px-8"
+        style={{ marginBottom: "0.5rem" }}
+      >
+        {weekDates.map((date) => (
           <div
             key={date.toISOString()}
             className="flex-1 text-center font-bold text-blue-700 text-xl"
@@ -211,41 +230,53 @@ export default function WeekCalendarView({
                             relative p-6 rounded-xl bg-white flex flex-col gap-2
                             w-full min-w-0
                             shadow transition cursor-pointer border-2
-                            ${isToday ? "border-blue-500 shadow-lg" : "border-gray-200"}
-                            ${ev.isPinned ? "border-blue-500" : "bg-gray-100 text-gray-300"}
+                            ${
+                              isToday
+                                ? "border-blue-500 shadow-lg"
+                                : "border-gray-200"
+                            }
+                            ${
+                              ev.isPinned
+                                ? "border-blue-500"
+                                : "bg-gray-100 text-gray-300"
+                            }
                           `}
                         >
-
-                        {ev.isPinned ? 
-                          (
+                          {ev.isPinned ? (
                             <div
                               onClick={(e) => {
-                              e.stopPropagation();
-                              handleRemove(e, ev);
-                            }}
+                                e.stopPropagation();
+                                handleRemove(e, ev);
+                              }}
                             >
-                              <div className="font-bold text-blue-800 text-lg">{ev.name}</div>
-                              <div className="text-base text-gray-700">{ev.placeFreeform}</div>
+                              <div className="font-bold text-blue-800 text-lg">
+                                {ev.name}
+                              </div>
+                              <div className="text-base text-gray-700">
+                                {ev.placeFreeform}
+                              </div>
                               <div className="text-base text-blue-600 font-bold">
-                                {new Date(ev.datetimeFrom).toLocaleDateString()}
+                                {/* Temp hide dates and times until they're working */}
+                                {/* {new Date(ev.datetimeFrom).toLocaleDateString()} */}
+                                {/* {moment(ev.datetimeFrom)
+                                  .subtract(9, "hours")
+                                  .format("LL")} */}
                               </div>
                               <div className="text-base">
-                                <b>Time:&nbsp;</b>
-                                {getTimeRange(ev)}
+                                {/* <b>Time:&nbsp;</b>
+                                {getTimeRange(ev)} */}
                               </div>
                             </div>
-
                           ) : (
                             <div
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleAdd(e, ev);
                               }}
-                              >
-                              { "Click to schedule " + ev.name }
+                            >
+                              {"Click to schedule " + ev.name}
                             </div>
-                          )
-                        }
+                          )}
                         </div>
                       );
                     })

--- a/client/src/components/WeekCalendarView.tsx
+++ b/client/src/components/WeekCalendarView.tsx
@@ -263,8 +263,8 @@ export default function WeekCalendarView({
                                   .format("LL")} */}
                               </div>
                               <div className="text-base">
-                                {/* <b>Time:&nbsp;</b>
-                                {getTimeRange(ev)} */}
+                                <b>Time:&nbsp;</b>
+                                {getTimeRange(ev)}
                               </div>
                             </div>
                           ) : (

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -63,4 +63,11 @@ export interface MetaData {
   label: string;
 }
 
+export interface StartEndInfo {
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+}
+
 export type LocationSearchType = "latLong" | "prefecture";

--- a/client/src/utils/eventUtils.ts
+++ b/client/src/utils/eventUtils.ts
@@ -1,20 +1,17 @@
 import type { FullEventType } from "../types";
+import fixTimeOffset from "./fixTimeOffSet";
 
 // Returns a string label for price, e.g. "Free" or "¥1,000"
 export function getPriceLabel(price: number) {
   if (price === 0) return "Free";
-  if (typeof price === "number" && !isNaN(price)) return `¥${price.toLocaleString()}`;
+  if (typeof price === "number" && !isNaN(price))
+    return `¥${price.toLocaleString()}`;
   return "";
 }
 
 export function getTimeRange(ev: FullEventType) {
-  const from = ev.datetimeFrom
-    ? new Date(ev.datetimeFrom).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-    : "-";
-  const to = ev.datetimeTo
-    ? new Date(ev.datetimeTo).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-    : "-";
-  return `${from} — ${to}`;
+  const { startTime, endTime } = fixTimeOffset(ev);
+  return `${startTime} — ${endTime}`;
 }
 
 export function getMonday(date: Date) {

--- a/client/src/utils/fixTimeOffSet.ts
+++ b/client/src/utils/fixTimeOffSet.ts
@@ -1,0 +1,15 @@
+import moment from "moment";
+import type { StartEndInfo, FullEventType } from "../types";
+
+export default function fixTimeOffset(event: FullEventType): StartEndInfo {
+  const startDate = moment(event.datetimeFrom)
+    .subtract(9, "hours")
+    .format("LL");
+  const endDate = moment(event.datetimeTo).subtract(9, "hours").format("LL");
+  const startTime = moment(event.datetimeFrom)
+    .subtract(9, "hours")
+    .format("LT");
+  const endTime = moment(event.datetimeTo).subtract(9, "hours").format("LT");
+
+  return { startDate, endDate, startTime, endTime };
+}

--- a/client/src/utils/getUniqueDates.ts
+++ b/client/src/utils/getUniqueDates.ts
@@ -3,7 +3,7 @@ import moment from "moment";
 
 export default function getUniqueDates(events: FullEventType[]): string[] {
   const allDates = events.map((event) => {
-    const formattedDate = moment(event.datetimeFrom);
+    const formattedDate = moment(event.datetimeFrom).subtract(9, "hours");
     return formattedDate.format("LL");
   });
   const uniqueDates = new Set(allDates);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -17,32 +17,35 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 
-let absolutePathReact = '/opt/render/project/src';
-let absolutePathStatic = './client/dist';
-if (process.env.NODE_ENV === 'development') {
+let absolutePathReact = "/opt/render/project/src";
+let absolutePathStatic = "./client/dist";
+if (process.env.NODE_ENV === "development") {
   absolutePathReact = process.cwd();
   absolutePathStatic = "../client/dist";
 }
 
-log.info('using those paths for express');
-log.info('absolutePathReact: ' + absolutePathReact);
-log.info('absolutePathStatic: ' + absolutePathStatic);
+log.info("using those paths for express");
+log.info("absolutePathReact: " + absolutePathReact);
+log.info("absolutePathStatic: " + absolutePathStatic);
 
 // to fix the static url problem (sharing link)
-let myHandler = function(req, res) {
-  res.sendFile((path.join(absolutePathReact, './client/dist/index.html')), function(err) {
-    if (err) {
-      res.status(500).send(err)
+let myHandler = function (req, res) {
+  res.sendFile(
+    path.join(absolutePathReact, "./client/dist/index.html"),
+    function (err) {
+      if (err) {
+        res.status(500).send(err);
+      }
     }
-  })
-}
+  );
+};
 
 app.use(express.static(absolutePathStatic));
-app.get('/', myHandler);
-app.get('/events', myHandler);
-app.get('/events/:a', myHandler);
-app.get('/timeline/public/:a', myHandler);
-app.get('/timeline', myHandler);
+app.get("/", myHandler);
+app.get("/event", myHandler);
+app.get("/event/:a", myHandler);
+app.get("/timeline/public/:a", myHandler);
+app.get("/timeline", myHandler);
 
 app.use("/media", express.static(`${config.mediaStoragePath}`));
 app.use("/api", eventRoute);
@@ -54,26 +57,28 @@ syncFirebaseUsers();
 
 async function testCache() {
   const myDocument = await eaCache.events.insert({
-      id: 'event1',
-      name: 'Fiesta !',
-      // done: false,
-      // timestamp: new Date().toISOString()
+    id: "event1",
+    name: "Fiesta !",
+    // done: false,
+    // timestamp: new Date().toISOString()
   });
   console.log("cache entry inserted)");
 
-  const foundDocuments = await eaCache.events.find({
-    selector: {
+  const foundDocuments = await eaCache.events
+    .find({
+      selector: {
         id: {
-            $eq: "event1"
-        }
-    }
-  }).exec();
+          $eq: "event1",
+        },
+      },
+    })
+    .exec();
 
   console.log("RESULT:");
   console.log(foundDocuments);
 }
 
-(async () =>  {
+(async () => {
   await initCache();
   // testCache();
 })();


### PR DESCRIPTION
# ✅ Resolves #[Issue number]

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected

## For assignee

### 🔧 What changed

#### Main fixes
- Events that were offset by 9 hours (rolling over to the next day in many cases) are patched to have correct times & dates. This affects search results, search result date groups, event details, and table view in timeline.
- Week view in timeline is not fully corrected yet, so noticeably incorrect date and time ranges have been hidden (commented out in the code).

#### Minor fixes
- Page title, Hero text, and navbar text are now consistently "Japan Events"
- `app.tx` client route has been corrected from `/events` to `/event`.

### 🧪 Testing instructions

- Visually confirm that dates are correct (vs original source link) and consistent within the app.
- Reloading an events detail page should be successful.

## For person submitting the PR

## Checklist

- [ ] PR focuses on only one feature or fix.
- [x] Feature or fix is complete (not a work in progress).
- [x] There is no dead code or large chunks of commented out code.
- [x] There are no unnecessary console.log statements.
- [ ] There feature/fix comes with tests when possible.
- [ ] All tests are passing (including tests not related to new feature/fix).
